### PR TITLE
JWT 및 로그인 관련 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,10 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation "io.jsonwebtoken:jjwt:0.9.1"
+    // JWT
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.3.1'

--- a/src/main/java/com/ssafy/motif/app/controller/MemberController.java
+++ b/src/main/java/com/ssafy/motif/app/controller/MemberController.java
@@ -12,12 +12,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/members")
+@RequestMapping("/api/v1/member")
 public class MemberController {
 
     private final MemberService memberService;
 
-    @PostMapping("/auth")
+    @PostMapping("/signup")
     public ResponseEntity<?> signup(@RequestBody SignupRequestDto requestDto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(memberService.signup(requestDto));
     }

--- a/src/main/java/com/ssafy/motif/app/controller/MemberController.java
+++ b/src/main/java/com/ssafy/motif/app/controller/MemberController.java
@@ -1,7 +1,9 @@
 package com.ssafy.motif.app.controller;
 
+import com.ssafy.motif.app.dto.member.LoginRequestDto;
 import com.ssafy.motif.app.dto.member.SignupRequestDto;
 import com.ssafy.motif.app.service.MemberService;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +22,12 @@ public class MemberController {
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@RequestBody SignupRequestDto requestDto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(memberService.signup(requestDto));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequestDto requestDto, HttpServletResponse response) {
+        memberService.login(requestDto, response);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
 }

--- a/src/main/java/com/ssafy/motif/app/controller/PostController.java
+++ b/src/main/java/com/ssafy/motif/app/controller/PostController.java
@@ -17,39 +17,38 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/posts/api")
 public class PostController {
-	private final PostService postService;
-	
-	@PostMapping("/write")
-	public ResponseEntity<?> postWrite(Post post){
-		postService.postWrite(post);
-		
-		return new ResponseEntity<>(HttpStatus.OK);
-	}
-	
-	@GetMapping("/list")
-	public ResponseEntity<?> postList(){
-		return ResponseEntity.ok(postService.postList());
-	}
-	
-	@PostMapping("/select/{postId}")
-	public ResponseEntity<?> postSelect(@PathVariable Long postId){
-		return ResponseEntity.ok(postService.postSelect(postId));
-		
-	}
-	
-	@PostMapping("/modify")
-	public ResponseEntity<?> postModify(Post post){
-		postService.postModify(post);
-		
-		return new ResponseEntity<>(HttpStatus.OK);
-		
-	}
-	
-	@PostMapping("/delete/{postId}")
-	public ResponseEntity<?> postDelete(@PathVariable Long postId){
-		postService.postDelete(postId);
-		
-		return new ResponseEntity<>(HttpStatus.OK);	
-	}
+
+    private final PostService postService;
+
+    @PostMapping("/write")
+    public ResponseEntity<?> postWrite(Post post) {
+        postService.postWrite(post);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<?> postList() {
+        return ResponseEntity.ok(postService.postList());
+    }
+
+
+    @PostMapping("/select/{postId}")
+    public ResponseEntity<?> postSelect(@PathVariable Long postId) {
+        return ResponseEntity.ok(postService.postSelect(postId));
+
+    }
+
+    @PostMapping("/modify")
+    public ResponseEntity<?> postModify(Post post) {
+        postService.postModify(post);
+        return new ResponseEntity<>(HttpStatus.OK);
+
+    }
+
+    @PostMapping("/delete/{postId}")
+    public ResponseEntity<?> postDelete(@PathVariable Long postId) {
+        postService.postDelete(postId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 
 }

--- a/src/main/java/com/ssafy/motif/app/dto/jwt/TokenDto.java
+++ b/src/main/java/com/ssafy/motif/app/dto/jwt/TokenDto.java
@@ -1,0 +1,18 @@
+package com.ssafy.motif.app.dto.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenDto {
+
+    private String email;
+    private String accessToken;
+    private String refreshToken;
+
+}

--- a/src/main/java/com/ssafy/motif/app/dto/member/LoginRequestDto.java
+++ b/src/main/java/com/ssafy/motif/app/dto/member/LoginRequestDto.java
@@ -1,0 +1,21 @@
+package com.ssafy.motif.app.dto.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequestDto {
+
+    private String email;
+    private String password;
+
+}

--- a/src/main/java/com/ssafy/motif/app/dto/member/LoginResponseDto.java
+++ b/src/main/java/com/ssafy/motif/app/dto/member/LoginResponseDto.java
@@ -1,0 +1,19 @@
+package com.ssafy.motif.app.dto.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponseDto {
+
+    private String email;
+    private String password;
+
+}

--- a/src/main/java/com/ssafy/motif/app/dto/member/SignupRequestDto.java
+++ b/src/main/java/com/ssafy/motif/app/dto/member/SignupRequestDto.java
@@ -1,5 +1,7 @@
 package com.ssafy.motif.app.dto.member;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -7,8 +9,10 @@ import lombok.ToString;
 
 @Getter
 @Setter
+@Builder
 @ToString
 @NoArgsConstructor
+@AllArgsConstructor
 public class SignupRequestDto {
 
     private Long memberId;

--- a/src/main/java/com/ssafy/motif/app/mapper/MemberMapper.java
+++ b/src/main/java/com/ssafy/motif/app/mapper/MemberMapper.java
@@ -1,7 +1,9 @@
 package com.ssafy.motif.app.mapper;
 
+import com.ssafy.motif.app.dto.member.LoginResponseDto;
 import com.ssafy.motif.app.dto.member.MemberResponseDto;
 import com.ssafy.motif.app.dto.member.SignupRequestDto;
+import java.util.Optional;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -12,5 +14,7 @@ public interface MemberMapper {
 
     boolean isEmailAlreadyInUse(@Param("email") String email);
 
-    MemberResponseDto findById(Long memberId);
+    MemberResponseDto findById(@Param("memberId") Long memberId);
+
+    Optional<LoginResponseDto> findByEmail(@Param("email") String email);
 }

--- a/src/main/java/com/ssafy/motif/app/mapper/RefreshTokenMapper.java
+++ b/src/main/java/com/ssafy/motif/app/mapper/RefreshTokenMapper.java
@@ -1,0 +1,49 @@
+package com.ssafy.motif.app.mapper;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.Optional;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface RefreshTokenMapper {
+
+    /**
+     * Refresh-Token - 이메일(UNQ)을 통한 조회
+     *
+     * @param email (토큰 소유자)
+     * @return (토큰 값)
+     */
+    Optional<String> getRefreshTokenByEmail(
+        @Param("email") String email
+    );
+
+    /**
+     * Refresh-Token - 회원당 최초 1회 생성
+     *
+     * @param value (토큰 값)
+     * @param email (토큰 소유자)
+     * @param expirationAt (토큰 만료 시점)
+     */
+    void createToken(
+        @Param("value") String value,
+        @Param("email") String email,
+        @Param("expirationAt") LocalDateTime expirationAt
+    );
+
+    /**
+     * Refresh-Token - 만료 시,
+     * 기존 토큰을 삭제 하는 것이 아닌 계속 새로 갱신 해서 재사용.
+     *
+     * @param value (토큰 값)
+     * @param email (토큰 소유자)
+     * @param expirationAt (토큰 만료 시점)
+     */
+    void updateToken(
+        @Param("value") String value,
+        @Param("email") String email,
+        @Param("expirationAt") Date expirationAt
+    );
+
+}

--- a/src/main/java/com/ssafy/motif/app/service/MemberService.java
+++ b/src/main/java/com/ssafy/motif/app/service/MemberService.java
@@ -1,8 +1,14 @@
 package com.ssafy.motif.app.service;
 
+import com.ssafy.motif.app.dto.jwt.TokenDto;
+import com.ssafy.motif.app.dto.member.LoginRequestDto;
 import com.ssafy.motif.app.dto.member.MemberResponseDto;
 import com.ssafy.motif.app.dto.member.SignupRequestDto;
+import javax.servlet.http.HttpServletResponse;
 
 public interface MemberService {
+
     MemberResponseDto signup(SignupRequestDto requestDto);
+
+    TokenDto login(LoginRequestDto requestDto, HttpServletResponse response);
 }

--- a/src/main/java/com/ssafy/motif/app/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/ssafy/motif/app/service/impl/MemberServiceImpl.java
@@ -1,38 +1,88 @@
 package com.ssafy.motif.app.service.impl;
 
+import com.ssafy.motif.app.dto.jwt.TokenDto;
+import com.ssafy.motif.app.dto.member.LoginRequestDto;
+import com.ssafy.motif.app.dto.member.LoginResponseDto;
 import com.ssafy.motif.app.dto.member.MemberResponseDto;
 import com.ssafy.motif.app.dto.member.SignupRequestDto;
 import com.ssafy.motif.app.exception.EmailDuplicateException;
 import com.ssafy.motif.app.mapper.MemberMapper;
+import com.ssafy.motif.app.mapper.RefreshTokenMapper;
 import com.ssafy.motif.app.service.MemberService;
+import com.ssafy.motif.app.util.cookie.CookieUtil;
+import com.ssafy.motif.app.util.jwt.JwtProvider;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
 
-    private final MemberMapper mapper;
+    private final JwtProvider JwtProvider;
+    private final CookieUtil cookieUtil;
+
     private final PasswordEncoder encoder;
+    private final MemberMapper memberMapper;
+    private final RefreshTokenMapper refreshTokenMapper;
+
 
     @Override
     @Transactional
     public MemberResponseDto signup(SignupRequestDto requestDto) {
         /* 이메일 중복 조사 */
-        emailValidation(requestDto);
+        validateEmail(requestDto);
         /* 비밀번호 암호화 */
         requestDto.setPassword(encoder.encode(requestDto.getPassword()));
         /* 회원가입 수행  */
-        mapper.signup(requestDto);
+        memberMapper.signup(requestDto);
         /* MemberResponseDto 반환 */
-        return mapper.findById(requestDto.getMemberId());
+        return memberMapper.findById(requestDto.getMemberId());
     }
 
+    @Override
+    @Transactional
+    public TokenDto login(LoginRequestDto requestDto, HttpServletResponse response) {
+        LoginResponseDto member = memberMapper.findByEmail(requestDto.getEmail()).orElseThrow(
+            () -> new IllegalArgumentException(requestDto.getEmail() + "= 존재하지 않는 회원입니다.")
+        );
 
-    private void emailValidation(SignupRequestDto requestDto) {
-        if (mapper.isEmailAlreadyInUse(requestDto.getEmail())) {
+        if (!encoder.matches(requestDto.getPassword(), member.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        TokenDto tokenDto = JwtProvider.generateTokenDto(member.getEmail());
+        /* 쿠키에 액세스 토큰 추가 */
+        cookieUtil.setCookie(
+            "Access_Token",
+            tokenDto.getAccessToken(),
+            JwtProvider.getAccessTokenTime(), response
+        );
+
+        /* 쿠키에 리프레쉬 토큰 추가 */
+        cookieUtil.setCookie(
+            "Refresh_Token",
+            tokenDto.getRefreshToken(),
+            JwtProvider.getRefreshTokenTime(), response
+        );
+
+        /* 리프레쉬 토큰 갱신 */
+        refreshTokenMapper.updateToken(
+            member.getEmail(),
+            tokenDto.getRefreshToken(),
+            JwtProvider.extractExpirationAt(tokenDto.getRefreshToken())
+        );
+
+        /* 로그인 성공 */
+        return tokenDto;
+    }
+
+    private void validateEmail(SignupRequestDto requestDto) {
+        if (memberMapper.isEmailAlreadyInUse(requestDto.getEmail())) {
             throw new EmailDuplicateException("이미 사용 중인 이메일 주소입니다.");
         }
     }

--- a/src/main/java/com/ssafy/motif/app/util/cookie/CookieUtil.java
+++ b/src/main/java/com/ssafy/motif/app/util/cookie/CookieUtil.java
@@ -1,0 +1,16 @@
+package com.ssafy.motif.app.util.cookie;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+    public void setCookie(String key, String value, int expiredTime, HttpServletResponse response) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(expiredTime);
+        response.addCookie(cookie);
+    }
+}

--- a/src/main/java/com/ssafy/motif/app/util/jwt/JwtFilter.java
+++ b/src/main/java/com/ssafy/motif/app/util/jwt/JwtFilter.java
@@ -1,0 +1,194 @@
+package com.ssafy.motif.app.util.jwt;
+
+import com.ssafy.motif.app.dto.jwt.TokenDto;
+import com.ssafy.motif.app.mapper.RefreshTokenMapper;
+import com.ssafy.motif.app.util.cookie.CookieUtil;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final CookieUtil cookieUtil;
+    private final RefreshTokenMapper mapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        log.debug("요청 URL : {}", request.getRequestURI());
+
+        /* 회원가입 혹은 로그인은 필터 패스 */
+        if (request.getRequestURI().equals("/api/v1/member/signup")
+            || request.getRequestURI().equals("/api/v1/member/login")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        /* 토큰 추출 */
+        String accessToken = extractToken("Access_Token", request);
+        String refreshToken = extractToken("Refresh_Token", request);
+        log.debug("accessToken : {} / refreshToken : {}", accessToken, refreshToken);
+
+
+        /* (상황1) 토큰이 둘 다 존재, */
+        if (accessToken != null && refreshToken != null) {
+            String email = jwtProvider.extractEmail(accessToken);
+            String refreshTokenOld = getRefreshTokenOld(email);
+
+            // 추출한 토큰과 DB에 있던 토큰 불일치,
+            verifyTokenMatch(refreshToken, refreshTokenOld);
+
+            // Access-Token 유효X ?
+            if (!jwtProvider.verifyToken(accessToken)) {
+
+                // Access-Token 유효X / Refresh-Token 유효X ?
+                if (!jwtProvider.verifyToken(refreshToken)) {
+                    throw new IllegalArgumentException("토큰 정보가 만료되었습니다.");
+                }
+
+                // Access-Token 유효X / Refresh-Token 유효O
+                else {
+                    reissue(email, response);
+                    setAuthentication(email, request);
+                }
+            }
+            // Access-Token 유효O / Refresh-Token 유효O
+            else {
+                setAuthentication(email, request);
+            }
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        /* (상황2) 액세스 토큰이 없을 경우, */
+        if (accessToken == null && refreshToken != null) {
+
+            String email = jwtProvider.extractEmail(refreshToken);
+            String refreshTokenOld = getRefreshTokenOld(email);
+
+            // 추출한 토큰과 DB에 있던 토큰 불일치,
+            verifyTokenMatch(refreshToken, refreshTokenOld);
+
+            // Refresh-Token 유효X ?
+            if (!jwtProvider.verifyToken(refreshToken)) {
+                throw new IllegalArgumentException("토큰 정보가 만료되었습니다.");
+            }
+
+            // Access-Token 유효O / Refresh-Token 유효O
+            else {
+                reissue(email, response);
+                setAuthentication(email, request);
+            }
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        /* (상황3) 리프레쉬 토큰이 없을 경우, */
+        if (accessToken != null && refreshToken == null) {
+
+            // Access-Token 유효X ?
+            if (!jwtProvider.verifyToken(accessToken)) {
+                throw new IllegalArgumentException("토큰 정보가 만료되었습니다.");
+            }
+
+            // Access-Token 유효O
+            else {
+                String email = jwtProvider.extractEmail(accessToken);
+                reissue(email, response);
+                setAuthentication(email, request);
+            }
+
+            filterChain.doFilter(request, response);
+        } else {
+            throw new IllegalArgumentException("접근 권한이 없습니다.");
+        }
+    }
+
+    private static void verifyTokenMatch(String refreshToken, String refreshTokenOld) {
+        if (!refreshToken.equals(refreshTokenOld)) {
+            throw new IllegalArgumentException("로그인 정보가 유효하지 않습니다.");
+        }
+    }
+
+    public void setAuthentication(String email, HttpServletRequest request) {
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(
+                email,
+                "",
+                Collections.singleton(new SimpleGrantedAuthority("USER"))
+            );
+
+        /* 웹 인증 세부 정보를 생성 */
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private void reissue(String email, HttpServletResponse response) {
+        TokenDto tokenDto = jwtProvider.generateTokenDto(email);
+
+        /* 쿠키에 액세스 토큰 추가 */
+        cookieUtil.setCookie(
+            "Access_Token",
+            tokenDto.getAccessToken(),
+            jwtProvider.getAccessTokenTime(), response
+        );
+
+        /* 쿠키에 리프레쉬 토큰 추가 */
+        cookieUtil.setCookie(
+            "Refresh_Token",
+            tokenDto.getRefreshToken(),
+            jwtProvider.getRefreshTokenTime(), response
+        );
+
+        /* 리프레쉬 토큰 갱신 */
+        updateRefreshToken(email, tokenDto.getRefreshToken());
+    }
+
+    @Transactional
+    public void updateRefreshToken(String email, String refreshToken) {
+        mapper.updateToken(
+            email,
+            refreshToken,
+            jwtProvider.extractExpirationAt(refreshToken)
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public String getRefreshTokenOld(String email) {
+        return mapper.getRefreshTokenByEmail(email).orElseThrow(
+            () -> new IllegalArgumentException("로그인 정보가 유효하지 않습니다.")
+        );
+    }
+
+    private String extractToken(String tokenType, HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            return Arrays.stream(cookies)
+                .filter(cookie -> tokenType.equals(cookie.getName()))
+                .findFirst()
+                .map(Cookie::getValue)
+                .orElse(null);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/ssafy/motif/app/util/jwt/JwtProvider.java
+++ b/src/main/java/com/ssafy/motif/app/util/jwt/JwtProvider.java
@@ -1,0 +1,130 @@
+package com.ssafy.motif.app.util.jwt;
+
+import com.ssafy.motif.app.dto.jwt.TokenDto;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import javax.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@PropertySource("classpath:application-secret.yml")
+public class JwtProvider {
+
+    @Value("${jwt.ACCESS_TIME}")
+    private int ACCESS_TOKEN_TIME;
+
+    @Value("${jwt.REFRESH_TIME}")
+    private int REFRESH_TOKEN_TIME;
+
+    @Value("${jwt.SECRET_KEY}")
+    private String SECRET_KEY;
+
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        key = Keys.hmacShaKeyFor(Base64.getDecoder().decode(SECRET_KEY));
+    }
+
+    /**
+     * @param email 유저의 이메일
+     * @return accessToken 과 refreshToken 이 담긴 token 객체를 리턴한다.
+     */
+    public TokenDto generateTokenDto(String email) {
+        return TokenDto.builder()
+            .accessToken(createAccessToken(email))
+            .refreshToken(createRefreshToken(email))
+            .email(email)
+            .build();
+    }
+
+    /**
+     * @param email - 회원 이메일
+     * @return ACCESS_TOKEN 발급
+     */
+    private String createAccessToken(String email) {
+        return Jwts.builder()
+            .setSubject(email)
+            .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_TIME))
+            .signWith(key)
+            .compact();
+    }
+
+    /**
+     * @param email - 회원 이메일
+     * @return REFRESH_TOKEN 발급
+     */
+    private String createRefreshToken(String email) {
+        return Jwts.builder()
+            .setSubject(email)
+            .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_TIME))
+            .signWith(key)
+            .compact();
+    }
+
+    /**
+     * @param token -> JWT claims
+     */
+    private Claims parseClaims(String token) {
+        try {
+            Claims body = Jwts.parser()
+                .setSigningKey(key)
+                .parseClaimsJws(token)
+                .getBody();
+            log.debug("========== 토큰 파싱 성공");
+            return body;
+        } catch (ExpiredJwtException e) {
+            log.warn("========== 만료된 토큰 : {}", token);
+            return e.getClaims();
+        }
+    }
+
+
+    /**
+     * @param token 검증 메서드
+     */
+    protected Boolean verifyToken(String token) {
+        try {
+            parseClaims(token);
+        } catch (ExpiredJwtException e) {
+            log.warn("========== 만료된 토큰 : {}", token);
+            return false;
+        } catch (UnsupportedJwtException | MalformedJwtException e) {
+            log.error("========== 잘못된 형식의 토큰 : {}", e.getMessage());
+            throw new IllegalArgumentException("로그인 정보 형식이 올바르지 않습니다.");
+        } catch (SignatureException e) {
+            log.error("========== 토큰 서명 문제 : {}", e.getMessage());
+            throw new IllegalArgumentException("로그인 정보가 변경되었습니다.");
+        }
+        return true;
+    }
+
+    protected String extractEmail(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    public Date extractExpirationAt(String token) {
+        return parseClaims(token).getExpiration();
+    }
+
+    public int getAccessTokenTime() {
+        return ACCESS_TOKEN_TIME;
+    }
+
+    public int getRefreshTokenTime() {
+        return REFRESH_TOKEN_TIME;
+    }
+
+}

--- a/src/main/java/com/ssafy/motif/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/motif/config/SecurityConfig.java
@@ -1,5 +1,10 @@
 package com.ssafy.motif.config;
 
+import com.ssafy.motif.app.mapper.RefreshTokenMapper;
+import com.ssafy.motif.app.util.cookie.CookieUtil;
+import com.ssafy.motif.app.util.jwt.JwtFilter;
+import com.ssafy.motif.app.util.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -8,10 +13,16 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final CookieUtil cookieUtil;
+    private final JwtProvider JwtProvider;
+    private final RefreshTokenMapper mapper;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity security) throws Exception {
@@ -28,6 +39,10 @@ public class SecurityConfig {
         security
             .authorizeRequests()
             .anyRequest().permitAll();
+
+        security
+            .addFilterBefore(new JwtFilter(JwtProvider, cookieUtil, mapper),
+                UsernamePasswordAuthenticationFilter.class);
 
         return security.build();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,5 @@
 spring:
   profiles:
     active: dev
+    include:
+      - secret

--- a/src/main/resources/mapper/member.xml
+++ b/src/main/resources/mapper/member.xml
@@ -4,10 +4,15 @@
 
 <mapper namespace="com.ssafy.motif.app.mapper.MemberMapper">
 
-  <resultMap id="member_response_dto" type="MemberResponseDto">
+  <resultMap id="Member_Response_Dto" type="MemberResponseDto">
     <result column="member_id" property="memberId"/>
     <result column="email" property="email"/>
     <result column="nickname" property="nickname"/>
+  </resultMap>
+
+  <resultMap id="Login_Response_Dto" type="LoginResponseDto">
+    <result column="email" property="email"/>
+    <result column="password" property="password"/>
   </resultMap>
 
   <select id="isEmailAlreadyInUse" resultType="boolean">
@@ -20,15 +25,21 @@
     WHERE email = #{email}
   </select>
 
-  <insert id="signup" parameterType="SignupRequestDto" useGeneratedKeys="true" keyProperty="memberId">
+  <insert id="signup" parameterType="SignupRequestDto" useGeneratedKeys="true"
+    keyProperty="memberId">
     INSERT INTO Members (email, password, username, nickname)
     VALUES (#{dto.email}, #{dto.password}, #{dto.username}, #{dto.nickname})
   </insert>
 
-  <select id="findById" parameterType="Long" resultMap="member_response_dto">
+  <select id="findById" resultMap="Member_Response_Dto">
     SELECT member_id, email, nickname
     FROM Members
     WHERE member_id = #{memberId}
   </select>
 
+  <select id="findByEmail" resultMap="Login_Response_Dto">
+    SELECT email, password
+    FROM Members
+    WHERE email = #{email};
+  </select>
 </mapper>

--- a/src/main/resources/mapper/refresh_token.xml
+++ b/src/main/resources/mapper/refresh_token.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ssafy.motif.app.mapper.RefreshTokenMapper">
+  <select id="getTokenValue" resultType="String">
+    SELECT token_value
+    FROM RefreshTokens
+    WHERE email = #{email}
+  </select>
+
+  <insert id="createToken">
+    INSERT INTO RefreshTokens(token_value, email, expiration_at)
+    VALUES (#{value}, #{email}, #{expirationAt});
+  </insert>
+
+  <update id="updateToken">
+    UPDATE RefreshTokens
+    SET token_value   = #{value},
+        expiration_at = #{expirationAt}
+    WHERE email = #{email}
+  </update>
+</mapper>

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,70 +1,75 @@
-CREATE TABLE IF NOT EXISTS ChatRoom
+CREATE TABLE IF NOT EXISTS Members
+(
+    member_id   BIGINT AUTO_INCREMENT PRIMARY KEY,
+    username    VARCHAR(30)                         NOT NULL,
+    nickname    VARCHAR(30)                         NOT NULL,
+    email       VARCHAR(100)                        NOT NULL UNIQUE,
+    password    VARCHAR(255)                        NOT NULL,
+    profile_img VARCHAR(255)                        NULL,
+    is_deleted  boolean   DEFAULT FALSE             NOT NULL,
+    created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    modified_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
+    INDEX (email)
+);
+
+CREATE TABLE IF NOT EXISTS ChatRooms
 (
     chatroom_id    bigint AUTO_INCREMENT
         PRIMARY KEY,
     chatroom_limit int                                 NOT NULL,
     chatroom_name  varchar(20)                         NOT NULL,
-    createdAt      timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    modifiedAt     timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP
+    is_deleted     boolean   DEFAULT FALSE             NOT NULL,
+    created_at     timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    modified_at    timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP
 );
 
-CREATE TABLE IF NOT EXISTS Members
-(
-    member_id   bigint AUTO_INCREMENT
-        PRIMARY KEY,
-    username    varchar(30)                         NOT NULL,
-    nickname    varchar(30)                         NOT NULL,
-    email       varchar(100)                        NOT NULL,
-    password    varchar(255)                        NOT NULL,
-    profile_img varchar(255)                        NULL,
-    createdAt   timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    modifiedAt  timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP
-);
 
-CREATE TABLE IF NOT EXISTS Chat
+CREATE TABLE IF NOT EXISTS Chats
 (
     chat_id     bigint AUTO_INCREMENT
         PRIMARY KEY,
-    message     text                                NOT NULL,
-    send_time   timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
     chatroom_id bigint                              NOT NULL,
     member_id   bigint                              NOT NULL,
-    createdAt   timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    modifiedAt  timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
+    message     text                                NOT NULL,
+    is_deleted  boolean   DEFAULT FALSE             NOT NULL,
+    created_at  timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    modified_at timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT FK_ChatRoom_TO_Chat_1
-        FOREIGN KEY (chatroom_id) REFERENCES ChatRoom (chatroom_id),
+        FOREIGN KEY (chatroom_id) REFERENCES ChatRooms (chatroom_id) ON DELETE CASCADE,
     CONSTRAINT FK_Members_TO_Chat_1
-        FOREIGN KEY (member_id) REFERENCES Members (member_id)
+        FOREIGN KEY (member_id) REFERENCES Members (member_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS Posts
 (
-    post_id    bigint AUTO_INCREMENT
+    post_id     bigint AUTO_INCREMENT
         PRIMARY KEY,
-    contents   text                                NOT NULL,
-    member_id  bigint                              NOT NULL,
-    createdAt  timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    modifiedAt timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
+    member_id   bigint                              NOT NULL,
+    contents    text                                NOT NULL,
+    is_deleted  boolean   DEFAULT FALSE             NOT NULL,
+    created_at  timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    modified_at timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT FK_Members_TO_Posts_1
-        FOREIGN KEY (member_id) REFERENCES Members (member_id)
+        FOREIGN KEY (member_id) REFERENCES Members (member_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS Comments
 (
-    comment_id bigint AUTO_INCREMENT
+    comment_id  bigint AUTO_INCREMENT
         PRIMARY KEY,
-    post_id    bigint                              NOT NULL,
-    member_id  bigint                              NOT NULL,
-    parents_id bigint                              NULL,
-    contents   text                                NOT NULL,
-    createdAt  timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    modifiedAt timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
+    post_id     bigint                              NOT NULL,
+    member_id   bigint                              NOT NULL,
+    parents_id  bigint                              NULL,
+    contents    text                                NOT NULL,
+    is_deleted  boolean   DEFAULT FALSE             NOT NULL,
+    created_at  timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    modified_at timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT FK_Comments_TO_Comments_1
-        FOREIGN KEY (parents_id) REFERENCES Comments (comment_id),
+        FOREIGN KEY (parents_id) REFERENCES Comments (comment_id) ON DELETE CASCADE,
     CONSTRAINT FK_Members_TO_Comments_1
-        FOREIGN KEY (member_id) REFERENCES Members (member_id),
+        FOREIGN KEY (member_id) REFERENCES Members (member_id) ON DELETE CASCADE,
     CONSTRAINT FK_Posts_TO_Comments_1
-        FOREIGN KEY (post_id) REFERENCES Posts (post_id)
+        FOREIGN KEY (post_id) REFERENCES Posts (post_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS Images
@@ -75,56 +80,72 @@ CREATE TABLE IF NOT EXISTS Images
     original_name varchar(255)                        NOT NULL,
     stored_name   varchar(255)                        NOT NULL,
     image_url     varchar(255)                        NOT NULL,
-    createdAt     timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    modifiedAt    timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
+    is_deleted    boolean   DEFAULT FALSE             NOT NULL,
+    created_at    timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    modified_at   timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT FK_Posts_TO_Images_1
-        FOREIGN KEY (post_id) REFERENCES Posts (post_id)
+        FOREIGN KEY (post_id) REFERENCES Posts (post_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS Likes
 (
-    like_id    bigint AUTO_INCREMENT
+    like_id     bigint AUTO_INCREMENT
         PRIMARY KEY,
-    post_id    bigint                              NOT NULL,
-    member_id  bigint                              NOT NULL,
-    createdAt  timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    modifiedAt timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
+    post_id     bigint                              NOT NULL,
+    member_id   bigint                              NOT NULL,
+    created_at  timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    modified_at timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT idx_member_post_unique
         UNIQUE (member_id, post_id),
     CONSTRAINT FK_Members_TO_Likes_1
-        FOREIGN KEY (member_id) REFERENCES Members (member_id),
+        FOREIGN KEY (member_id) REFERENCES Members (member_id) ON DELETE CASCADE,
     CONSTRAINT FK_Posts_TO_Likes_1
-        FOREIGN KEY (post_id) REFERENCES Posts (post_id)
+        FOREIGN KEY (post_id) REFERENCES Posts (post_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS TimeTables
 (
     timetable_id   bigint AUTO_INCREMENT
         PRIMARY KEY,
-    timetable_name varchar(20)                         NULL,
-    date           timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
     member_id      bigint                              NOT NULL,
-    createdAt      timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    modifiedAt     timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
+    timetable_name varchar(30)                         NOT NULL,
+    date           timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    is_deleted     boolean   DEFAULT FALSE             NOT NULL,
+    created_at     timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    modified_at    timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT FK_Members_TO_TimeTables_1
-        FOREIGN KEY (member_id) REFERENCES Members (member_id)
+        FOREIGN KEY (member_id) REFERENCES Members (member_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS Schedules
 (
     schedule_id  bigint AUTO_INCREMENT
         PRIMARY KEY,
+    timetable_id bigint                              NOT NULL,
     name         varchar(20)                         NOT NULL,
     category     varchar(10)                         NOT NULL,
-    x_coordinate double                              NOT NULL,
-    y_coordinate double                              NOT NULL,
-    start_time   timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    end_time     timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    latitude     double                              NOT NULL,
+    longitude    double                              NOT NULL,
+    start_time   timestamp                           NOT NULL,
+    end_time     timestamp                           NOT NULL,
     color_code   char(7)   DEFAULT '#000000'         NOT NULL,
-    timetable_id bigint                              NOT NULL,
-    createdAt    timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    modifiedAt   timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
+    created_at   timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    modified_at  timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT FK_TimeTables_TO_Schedules_1
-        FOREIGN KEY (timetable_id) REFERENCES TimeTables (timetable_id)
+        FOREIGN KEY (timetable_id) REFERENCES TimeTables (timetable_id) ON DELETE CASCADE
+);
+
+
+CREATE TABLE IF NOT EXISTS RefreshTokens
+(
+    token_id      BIGINT AUTO_INCREMENT PRIMARY KEY,
+    token_value   VARCHAR(255)                        NOT NULL,
+    email         VARCHAR(100)                        NOT NULL UNIQUE,
+    status        VARCHAR(20)                         NOT NULL DEFAULT 'active',
+    expiration_at TIMESTAMP                           NOT NULL,
+    created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    modified_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT FK_Members_TO_RefreshTokens_1
+        FOREIGN KEY (email) REFERENCES Members (email) ON DELETE CASCADE
 );
 

--- a/src/test/java/com/ssafy/motif/app/controller/MemberControllerTest.java
+++ b/src/test/java/com/ssafy/motif/app/controller/MemberControllerTest.java
@@ -47,7 +47,7 @@ class MemberControllerTest {
 
         //when
         final ResultActions result =
-            mvc.perform(post("/api/v1/members/auth")
+            mvc.perform(post("/api/v1/member/signup")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(data))
                 .andDo(print());
@@ -57,28 +57,5 @@ class MemberControllerTest {
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.email").value(requestDto.getEmail()));
     }
-
-//    @Test
-//    @DisplayName("회원가입 - 실패(유효성 실패)")
-//    public void 회원가입2() throws Exception {
-//
-//        // given
-//        SignupRequestDto requestDto = new SignupRequestDto();
-//        requestDto.setEmail("test@test.com");
-//        requestDto.setPassword("123123");
-//        requestDto.setNickname("HongGilDong");
-//
-//        String data = mapper.writeValueAsString(requestDto);
-//
-//        //when
-//        mvc.perform(post("/api/v1/members/auth")
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .content(data))
-//            .andDo(print())
-//            .andExpect(status().is5xxServerError())
-//            .andExpect(result -> assertTrue(
-//                result.getResolvedException() instanceof DataIntegrityViolationException));
-//    }
-
 
 }

--- a/src/test/java/com/ssafy/motif/app/util/jwt/JwtProviderTest.java
+++ b/src/test/java/com/ssafy/motif/app/util/jwt/JwtProviderTest.java
@@ -1,0 +1,36 @@
+package com.ssafy.motif.app.util.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ssafy.motif.app.dto.jwt.TokenDto;
+import java.util.Date;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class JwtProviderTest {
+
+    @Autowired
+    JwtProvider JwtProvider;
+
+    @Test
+    @DisplayName("토큰 생성과 검증 테스트")
+    public void 토큰_테스트() throws Exception {
+
+        // given
+        final String email = "test@test.com";
+
+        // when
+        TokenDto tokenDto = JwtProvider.generateTokenDto(email);
+
+        // then
+        assertThat(JwtProvider.extractEmail(tokenDto.getAccessToken())).isEqualTo(email);
+        assertThat(JwtProvider.extractExpirationAt(tokenDto.getAccessToken())).isAfter(new Date(System.currentTimeMillis()));
+        assertThat(JwtProvider.extractExpirationAt(tokenDto.getRefreshToken())).isAfter(new Date(System.currentTimeMillis()));
+    }
+
+
+
+}


### PR DESCRIPTION
- [X] JWT 을 위한 RefreshTokens 테이블 생성
- [X] Schedules 테이블 x좌표, y좌표가 아닌 위도(latitude), 경도(longtitue)로 컬럼명 변경
- [X] 각 테이블에 참조 테이블 관계에서 CASCADE 를 통해 부모와 함께 삭제되도록 옵션 추가.
- [X] Soft Delete 를 위해 모든 테이블에 is_deleted 컬럼 추가.
- [X] 생성, 수정시점 컬럼명 카멜케이스 -> 스네이크 케이스로 변경
- [X] JWT 버전 상향 0.9.1 -> 0.11.2
- [X] 회원가입 /auth -> /signup 수정.
- [X] 비밀키 파일 추가.
- [X] Access-Token 과 Refresh-Token 각각 발급하여 TokenDto 로 담아서 반환.
- [X] JWT 토큰 발급 및 기본검증 테스트 수행.
- [X] Access-Token과 Refresh-Token 을 HttpOnly 를 설정한 쿠키에 담아서 클라이언트로 보내기 위해서, 쿠키 유틸리티 클래스를 추가.
- [X] 토큰 생성과 조회, 업데이트를 위한 SQL 매퍼 기능.
- [X] 여러 토큰의 유효 상황에 맞추어 대응할 수 있도록 필터링 기능을 구현. -> 각 상황에 맞게 JWT 재발행 수행
- [X] UsernamePasswordAuthenticationFilter 이전에 커스텀 필터를 추가.
- [X] 두 DTO 는 기능상 차이는 없지만, 이름을 통해 프로세스의 흐름을 명확히 하기 위해서 생성.
- [X] 이메일을 통한 로그인 응답객체 생성 매퍼 추가.
- [X] 로그인 요청 객체를 통해, 적절한 JWT 를 생성하여 클라이언트로 쿠키를 통해 반환.
- [X] 로그인 API 구현.
- [X] 로그인을 성공적으로 수행할 경우, 쿠키에 토큰 여부 확인.
- [ ] 실패 시나리오는 이후에 추가로 수행할 예정.
- [X] Post 컨트롤러 코드 포맷팅.
 