### PR TITLE
Post data paging 기능 추가

### DIFF
--- a/src/main/java/com/ssafy/motif/app/controller/PostController.java
+++ b/src/main/java/com/ssafy/motif/app/controller/PostController.java
@@ -31,10 +31,11 @@ public class PostController {
         postService.create(requestDto, authentication.getName());
         return ResponseEntity.status(HttpStatus.CREATED).body(requestDto);
     }
-
-    @GetMapping("/list")
-    public ResponseEntity<?> postList() {
-        return ResponseEntity.ok(postService.postList());
+    
+    @GetMapping("/paging/{pageId}")
+    public ResponseEntity<?> postPaging(@PathVariable int pageId){
+    	int size=20; // 페이징 사이즈
+    	return ResponseEntity.ok(postService.postPaging(pageId, size));
     }
 
     @GetMapping("/select/{postId}")

--- a/src/main/java/com/ssafy/motif/app/domain/dto/post/PageRequest.java
+++ b/src/main/java/com/ssafy/motif/app/domain/dto/post/PageRequest.java
@@ -1,0 +1,19 @@
+package com.ssafy.motif.app.domain.dto.post;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PageRequest { // 페이징 요청을 위한 Dto
+	private int pageId;
+	private int size;
+	
+	public int getSkip() {
+		return (pageId-1)*size;
+	}
+
+}

--- a/src/main/java/com/ssafy/motif/app/domain/dto/post/PagingResponse.java
+++ b/src/main/java/com/ssafy/motif/app/domain/dto/post/PagingResponse.java
@@ -1,0 +1,14 @@
+package com.ssafy.motif.app.domain.dto.post;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor(access=AccessLevel.PROTECTED)
+public class PagingResponse {
+	private Long postId;
+	private String contents;
+	private Long memberId;
+	private String createdAt;
+}

--- a/src/main/java/com/ssafy/motif/app/domain/mapper/PostMapper.java
+++ b/src/main/java/com/ssafy/motif/app/domain/mapper/PostMapper.java
@@ -1,10 +1,13 @@
 package com.ssafy.motif.app.domain.mapper;
 
-import com.ssafy.motif.app.domain.dto.post.PostRequestDto;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+
+import com.ssafy.motif.app.domain.dto.post.PageRequest;
+import com.ssafy.motif.app.domain.dto.post.PostRequestDto;
+import com.ssafy.motif.app.domain.dto.post.PagingResponse;
 
 @Mapper
 public interface PostMapper {
@@ -15,7 +18,7 @@ public interface PostMapper {
 	 */
 	void save(@Param("dto") PostRequestDto dto, @Param("memberId") Long memberId);
 
-	List<PostRequestDto> postList();
+	List<PagingResponse> postPaging(PageRequest pageRequest);
 	PostRequestDto postSelect(Long postId);
 	void postModify(PostRequestDto postRequestDto);
 	void postDelete(Long postId);

--- a/src/main/java/com/ssafy/motif/app/service/PostService.java
+++ b/src/main/java/com/ssafy/motif/app/service/PostService.java
@@ -1,11 +1,13 @@
 package com.ssafy.motif.app.service;
 
-import com.ssafy.motif.app.domain.dto.post.PostRequestDto;
 import java.util.List;
+
+import com.ssafy.motif.app.domain.dto.post.PostRequestDto;
+import com.ssafy.motif.app.domain.dto.post.PagingResponse;
 
 public interface PostService {
 	void create(PostRequestDto postRequestDto, String email);
-	List<PostRequestDto> postList();
+	List<PagingResponse> postPaging(int pageId, int size);
 	PostRequestDto postSelect(Long postId);
 	void postModify(PostRequestDto postRequestDto);
 	void postDelete(Long postId);

--- a/src/main/java/com/ssafy/motif/app/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/ssafy/motif/app/service/impl/PostServiceImpl.java
@@ -1,17 +1,19 @@
 package com.ssafy.motif.app.service.impl;
 
-import com.ssafy.motif.app.domain.dto.member.LoginResponseDto;
-import com.ssafy.motif.app.domain.dto.post.PostRequestDto;
-import com.ssafy.motif.app.domain.mapper.MemberMapper;
 import java.util.List;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import com.ssafy.motif.app.domain.dto.member.LoginResponseDto;
+import com.ssafy.motif.app.domain.dto.post.PageRequest;
+import com.ssafy.motif.app.domain.dto.post.PostRequestDto;
+import com.ssafy.motif.app.domain.dto.post.PagingResponse;
+import com.ssafy.motif.app.domain.mapper.MemberMapper;
 import com.ssafy.motif.app.domain.mapper.PostMapper;
 import com.ssafy.motif.app.service.PostService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
@@ -35,8 +37,10 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public List<PostRequestDto> postList() {
-        return postMapper.postList();
+    public List<PagingResponse> postPaging(int pageId, int size) {
+    	PageRequest pReq=new PageRequest(pageId, size);
+    	log.info("paging request:"+pReq.toString());
+        return postMapper.postPaging(pReq);
     }
 
     @Override

--- a/src/main/resources/mapper/post.xml
+++ b/src/main/resources/mapper/post.xml
@@ -8,15 +8,24 @@
     <result column="contents" property="contents"/>
     <result column="member_id" property="memberId"/>
   </resultMap>
+  
+  <resultMap type="PagingResponse" id="paging">
+    <result column="post_id" property="postId"/>
+    <result column="contents" property="contents"/>
+    <result column="member_id" property="memberId"/>
+    <result column="created_at" property="createdAt"/>
+  </resultMap>
 
   <insert id="save" useGeneratedKeys="true" keyProperty="dto.postId">
     INSERT INTO Posts(title, contents, member_id)
     VALUES (#{dto.title}, #{dto.contents}, #{memberId})
   </insert>
 
-  <select id="postList" resultMap="requestDto">
-    SELECT post_id, contents, member_id
-    FROM posts
+  <select id="postPaging" parameterType="PageRequest" resultMap="paging">
+    SELECT post_id, contents, member_id, created_at
+    FROM Posts
+    ORDER BY created_at DESC
+    LIMIT #{skip}, #{size}
   </select>
 
   <select id="postSelect" parameterType="Long" resultMap="requestDto">


### PR DESCRIPTION
- 기능 설명: 클라이언트에서 필요한 페이지 넘버(int)를 보내면 상응하는 페이지 데이터를 size만큼 return

- 변동 사항
1. paging을 위한 dto 추가
2. post.xml 테이블명 첫글자 대문자로 변경(쿼리 인식문제)
3. 기존의 전체 post를 불러오는 postList 메소드 삭제